### PR TITLE
Islandora 1414

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ Install as usual, see [this](https://drupal.org/documentation/install/modules-th
 
 Create and import forms at Administration » Form Builder (admin/islandora/xmlform).
 
+## Documentation
+
+Further documentation for this module is available at [our wiki](https://wiki.duraspace.org/display/ISLANDORA/XML+Forms).
+
 ## Troubleshooting/Issues
 
 Having problems or solved a problem? Check out the Islandora google groups for a solution.
@@ -101,7 +105,7 @@ Current maintainers:
 
 ## Development
 
-If you would like to contribute to this module, please check out our helpful [Documentation for Developers](https://github.com/Islandora/islandora/wiki#wiki-documentation-for-developers) info, as well as our [Developers](http://islandora.ca/developers) section on the Islandora.ca site.
+If you would like to contribute to this module, please check out [CONTRIBUTING.md](CONTRIBUTING.md). In addition, we have helpful [Documentation for Developers](https://github.com/Islandora/islandora/wiki#wiki-documentation-for-developers) info, as well as our [Developers](http://islandora.ca/developers) section on the [Islandora.ca](http://islandora.ca) site.
 
 ## License
 

--- a/elements/includes/Tags.inc
+++ b/elements/includes/Tags.inc
@@ -225,7 +225,6 @@ function template_preprocess_tags(&$vars) {
   $textfield = array(
     'element' => array_shift($vars['tags']),
   );
-  $textfield['element']['#id'] = $tags['#id'];
   $textfield['element']['#size'] = $tags['#size'];
   $textfield['element']['#autocomplete_path'] = isset($textfield['element']['#autocomplete_path']) ? $textfield['element']['#autocomplete_path'] : FALSE;
   // Theme the text field to take advantage of autocomplete.

--- a/elements/xml_form_elements.module
+++ b/elements/xml_form_elements.module
@@ -370,6 +370,8 @@ function xml_form_elements_form_element_tags_ajax_add(FormElement $element, arra
   $input->parent->adopt($tag);
   $tag = $tag->toArray();
   $tag['#default_value'] = $default_value;
+  //Since cloned tags are not textfields just unset #autocomplete_path key.
+  unset($tag['#autocomplete_path']);
   // Update drupal form.
   $form[] = $tag;
 }


### PR DESCRIPTION
Ultra simple fix for Drupal 7.39 Autocomplete functionality on tags
based on @slangerx identification and previous fix. We no longer
reassign element #id for textfield in the
template_preprocess_tags(&$vars) , we use the same hash assigned
initially. Tested on  Drupal 7.37-7.39 with blank form and form using
templates pre filled for tags.
